### PR TITLE
Make System Prompt Arg Available for Local Chat Model Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ python -m mix_eval.evaluate \
 
 <br>
 
+# Use System Prompt as part of Chat Evaluation
+The recent changes offer usage of local chat models. If you want to set your own to see how it influences your model performance, you can use:
+```
+--system_prompt "Speak like Jar Jar Binks, and you have been always the hidden overlord!"
+```
+
+
+
 # Registering New Models
 **(Step 1)** Add your model file to `mixeval/models/` with name `your_model_name.py` and write the model class in it with the name `Model_Class_Name`. 
 - Open-source chat models are inherited from `mixeval.models.base.ChatModel` (example file: `llama_3_8b_instruct.py`).

--- a/mix_eval/evaluate.py
+++ b/mix_eval/evaluate.py
@@ -50,6 +50,12 @@ def parse_args():
         help="Path to local model, only work with model_name='local_chat'."
         )
     parser.add_argument(
+        "--model_systemprompt", 
+        type=str, 
+        required=False, 
+        help="Model systemprompt available for local_chat model"
+        )
+    parser.add_argument(
         "--benchmark", 
         type=str, 
         required=True, 

--- a/mix_eval/models/local_chat.py
+++ b/mix_eval/models/local_chat.py
@@ -13,7 +13,10 @@ class LocalChatModel(ChatModel):
         self.model_dtype = torch.bfloat16
         self.trust_remote_code = True
         
-        self.SYSTEM_MESSAGE = None
+        if args.model_systemprompt:
+            self.SYSTEM_MESSAGE = {"role": "system", "content": args.model_systemprompt}
+        else:
+            self.SYSTEM_MESSAGE = None
         self.USER_MESSAGE_TEMPLATE = lambda x: {"role": "user", "content": x}
         self.ASSISTANT_MESSAGE_TEMPLATE = lambda x: {"role": "assistant", "content": x}
 


### PR DESCRIPTION
This PR introduces the ability to pass a system prompt dynamically as part of the evaluation process for local chat models. To achieve this, I've added a new argument to the evaluation process, updated the local chat file and the evaluate file to handle this argument, and added a brief comment to the README file for clarity.
Changes:

- Added a new argument to the evaluation process to pass the system prompt dynamically
- Updated local_chat file to handle the new argument
- Updated evaluate file to pass the new argument to local_chat
- Added a brief comment to the README file for context

Thank you for your efforts!
