### PR TITLE
Default Local Chat Tokenizer Padding Side "left" for multi batch inference

### DIFF
--- a/mix_eval/models/local_chat.py
+++ b/mix_eval/models/local_chat.py
@@ -33,5 +33,6 @@ class LocalChatModel(ChatModel):
         tokenizer = AutoTokenizer.from_pretrained(
             self.model_name,
             model_max_length=self.model_max_len,
-            trust_remote_code=self.trust_remote_code)
+            trust_remote_code=self.trust_remote_code,
+            padding_side="left")
         return tokenizer


### PR DESCRIPTION
This PR sets the default local_chat tokenizer padding to left to ensure consistent behavior across models. Without explicit specification, padding side can be incorrect, depending on the use case (e.g., training vs inference). This change is crucial for our Multi-batch inference in MixEval, which requires left padding.

For reference, Hugging Face's best practice and explanation can be found here: https://huggingface.co/docs/transformers/llm_tutorial#wrong-padding-side

Thank you for your efforts!