### PR TITLE
Handling default Padding Token and offer System Prompt

### DIFF
--- a/mix_eval/models/local_chat.py
+++ b/mix_eval/models/local_chat.py
@@ -13,7 +13,10 @@ class LocalChatModel(ChatModel):
         self.model_dtype = torch.bfloat16
         self.trust_remote_code = True
         
-        self.SYSTEM_MESSAGE = None
+        if args.model_systemprompt:
+            self.SYSTEM_MESSAGE = {"role": "system", "content": args.model_systemprompt}
+        else:
+            self.SYSTEM_MESSAGE = None
         self.USER_MESSAGE_TEMPLATE = lambda x: {"role": "user", "content": x}
         self.ASSISTANT_MESSAGE_TEMPLATE = lambda x: {"role": "assistant", "content": x}
 
@@ -33,5 +36,8 @@ class LocalChatModel(ChatModel):
         tokenizer = AutoTokenizer.from_pretrained(
             self.model_name,
             model_max_length=self.model_max_len,
-            trust_remote_code=self.trust_remote_code)
+            trust_remote_code=self.trust_remote_code,
+            )
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
         return tokenizer


### PR DESCRIPTION
hi @Psycoy This PR handles:
- not set padding tokens as it is a problem within e.g. LLAMA 3 8B Instruct. We set it per default to EOS token as this is an appropriate default token in inference. 
- Additionally we offer setting of system props over arg as it influences models results and is petter an arg and not a hardcoded string

thank you for your efforts.
kindest regards
Carsten