### PR TITLE
Padding Handling for Local Chat

### DIFF
--- a/mix_eval/models/local_chat.py
+++ b/mix_eval/models/local_chat.py
@@ -33,5 +33,6 @@ class LocalChatModel(ChatModel):
         tokenizer = AutoTokenizer.from_pretrained(
             self.model_name,
             model_max_length=self.model_max_len,
+            padding_side=self.padding_side,
             trust_remote_code=self.trust_remote_code)
         return tokenizer

--- a/mix_eval/models/local_chat.py
+++ b/mix_eval/models/local_chat.py
@@ -33,6 +33,5 @@ class LocalChatModel(ChatModel):
         tokenizer = AutoTokenizer.from_pretrained(
             self.model_name,
             model_max_length=self.model_max_len,
-            padding_side=self.padding_side,
             trust_remote_code=self.trust_remote_code)
         return tokenizer


### PR DESCRIPTION
Hello :) 

This PR fixes issues with Inference by using local chat. as local chat overwrites build transformer of Base it does not include the default padding = left which is needed for inference. The PR only changes the one needed line. 

regards
Carsten